### PR TITLE
updated to faker ^4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "mocha": "^2.4.5"
   },
   "dependencies": {
-    "faker": "^3.0.1",
+    "faker": "^4.1.0",
     "feathers": "^2.0.0",
     "feathers-errors": "^2.0.1",
     "feathers-hooks": "^1.5.0",


### PR DESCRIPTION
This update simply bumps faker to the latest version. 
I needed to use 'lorem.slug' which does not yet exist in your version of fakerJS.